### PR TITLE
chore(mocha): move script options into shared config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "babel src --out-dir lib",
     "build:umd": "webpack src/index.js dist/library-boilerplate.js && NODE_ENV=production webpack src/index.js dist/library-boilerplate.min.js",
     "lint": "eslint src test examples",
-    "test": "NODE_ENV=test mocha --compilers js:babel/register --recursive",
-    "test:watch": "NODE_ENV=test mocha --compilers js:babel/register --recursive --watch",
-    "test:cov": "babel-node ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha -- --recursive",
+    "test": "NODE_ENV=test mocha",
+    "test:watch": "NODE_ENV=test mocha --watch",
+    "test:cov": "babel-node ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build && npm run build:umd"
   },
   "repository": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--compilers js:babel/register
+--recursive


### PR DESCRIPTION
Hey Dan!

I really love this library boilerplate. Thanks for sharing it :)

I've recently been deep in the throws of mocha/testing config and I thought I'd make this PR. It's mostly cosmetic but helpful when end-developers would might attempt to use `node_modules/.bin/mocha` directly.
### Job Story:

When I generate a new component, I want to pass arbitrary flags directly
to a command-line tool, so I can use options I know without the friction
of additional config.
### Approach:

I've moved all shared mocha mocha flags to `test/mocha.opts`. This
allows for direct use of the `mocha` cli via `node_modules/.bin/mocha`,
while perserving the expected `compiler` and `recursive` flags.
### Outcome:

`$ node_modules/.bin/mocha` runs with the same default options as `npm test`.

`test:watch` and `test:cov` continue to work as expected.
