### PR TITLE
chore(mocha): provide global.document stub for React shallowRenderer

### DIFF
--- a/test/utils/document.js
+++ b/test/utils/document.js
@@ -1,0 +1,3 @@
+if (typeof document === "undefined") {
+  global.document = {};
+}


### PR DESCRIPTION
## Issue:

When using `shallowRenderer`, tests invoking `setState` will fail
with a `document is not defined` reference error.
## Job Story:

When I write tests invoking `setState`, I want it to pass without requiring a DOM, so that I
don't have to install jsdom.
## Solution:

Provide a `global.document` mock as part of `mocha.opts` config.
### Test case:

```
import expect from 'expect';
import { add } from '../src';

import React from 'react/addons';

describe('shallowRenderer event tests work without jsdom', () => {
  class Tester extends React.Component {
    constructor(props) {
      super(props);
      this.state = { foo: "bar" };
      this.handleClick = () => { this.setState({foo: "baz"}) };
    }
    render () {
      return <div onClick={this.handleClick}>{this.state.foo}</div>;
    }
  }

  let shallowRenderer = React.addons.TestUtils.createRenderer();

  it('shallow renderer works', () => {
    shallowRenderer.render(<Tester />);
    let result = shallowRenderer.getRenderOutput();
    expect(result.props.children).toBe("bar");

    result.props.onClick();
    let newResult = shallowRenderer.getRenderOutput();
    expect(newResult.props.children).toBe("baz");
  });
});
```
## Side effects:

None known.
