### PR TITLE
fix(mocha/document): resolve eslint single-string error

### DIFF
--- a/test/utils/document.js
+++ b/test/utils/document.js
@@ -1,3 +1,3 @@
-if (typeof document === "undefined") {
+if (typeof document === 'undefined') {
   global.document = {};
 }


### PR DESCRIPTION
Dan, I'm really sorry but I broke a few commands by introducing an eslint error. This PR patches that error and puts everything back to normal.
# Issue:

The addition of `document.js` in PR #6 had a `quotes` linting error. This caused commands like `npm install` to fail.
# Resolution:

Change quotes from "double" to "single" in line 1 of `test/utils/document.js`.
